### PR TITLE
Remove setTimout in server

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import express from 'express'
+import { Network, Environment, RecordSource, Store } from 'relay-runtime'
 import App from './components/App'
 import { renderToString } from 'react-dom/server'
 import { createRelayEnvironment } from './relayEnvironment'
@@ -11,31 +12,33 @@ app.get('/', async (req, res, next) => {
   renderToString(<App environment={environment} />)
   const relayData = await environment.relaySSRMiddleware.getCache()
 
-  setTimeout(() => {
-    const html = renderToString(<App environment={environment} />)
+  const source = new RecordSource()
+  const store = new Store(source)
+  const html = renderToString(
+    <App
+      environment={new Environment({
+        network: Network.create(() => relayData[0][1]),
+        store,
+      })}
+    />
+  )
 
-    try {
-      res.status(200).send(`
-      <html>
-        <head>
-          <title>Relay Modern SSR Example</title>
-        </head>
-        <body>
-          <div id="react-root">${html}</div>
+  res.status(200).send(`
+    <html>
+      <head>
+        <title>Relay Modern SSR Example</title>
+      </head>
+      <body>
+        <div id="react-root">${html}</div>
 
-          <script>
-            window.__RELAY_BOOTSTRAP_DATA__ = ${JSON.stringify(relayData)};
-          </script>
+        <script>
+          window.__RELAY_BOOTSTRAP_DATA__ = ${JSON.stringify(relayData)};
+        </script>
 
-          <script src="/assets/artworks.js"></script>
-        </body>
-      </html>
-    `)
-    } catch (error) {
-      console.log('(server.js) Error: ', error) // eslint-disable-line
-      next(error)
-    }
-  }, 0)
+        <script src="/assets/artworks.js"></script>
+      </body>
+    </html>
+  `)
 })
 
 export default app


### PR DESCRIPTION
I think we should not use `setTimeout` in `server`.
Most of tools, like `next.js` will use `renderToString` directly, they do not use `setTimout` before `renderToString`.
This is more useful to others who want to use `react-relay-network-modern-ssr` in the tool.